### PR TITLE
Extract gene names without solution while markers init

### DIFF
--- a/R/Linseed2Solver.R
+++ b/R/Linseed2Solver.R
@@ -77,7 +77,7 @@ Linseed2Solver <- R6Class(
           }
         } else if (genes && !is.null(self$st$marker_genes) && (color == "markers")) {
           name <- color
-          color <- which_marker(rownames(self$st$solution$W), self$st$marker_genes)
+          color <- which_marker(rownames(self$st$data), self$st$marker_genes)
         } else if (color %in% colnames(anno)) {
           name <- color
           color <- anno[, color]


### PR DESCRIPTION
This commit makes it possible to pass markers to be colored during projection plot. 

Please correct me if I extracted gene names wrong. 
(It would be great to have obvious name for V matrix as we had in previous version

## Example code
```
markers_list <- get_signature_markers(bas, n_marker_genes = 60)
lo2$st$marker_genes <- markers_list
lo2$plot_projected(color_genes = "markers",  with_solution = T, with_history = F)
```
![image](https://github.com/artyomovlab/linseed2/assets/19429157/30a998a9-f486-4dbb-8030-8583b1091e75)


