### PR TITLE
Fixed single error variable plot

### DIFF
--- a/R/optimization.R
+++ b/R/optimization.R
@@ -212,7 +212,7 @@ plot_errors <- function(
     "total_error"
   )
 ) {
-  to_plot <- data.frame(solution_proj$optim_history$errors_statistics[, variables])
+  to_plot <- data.frame(solution_proj$optim_history$errors_statistics[, variables, drop=F])
   to_plot$iteration <- 0:(nrow(solution_proj$optim_history$errors_statistics) - 1)
   to_plot <- reshape2::melt(to_plot, id.vars = "iteration", measure.vars = variables)
   plt <-


### PR DESCRIPTION
We had a problem when error plot is  broken if ask for single variable. 
![image](https://github.com/artyomovlab/linseed2/assets/19429157/031c87fd-4395-44ec-9905-cfc5a55542b2)
this is because data.frame simplifies something and renames column