### PR TITLE
For NMF: return H_row and V_row as well from reverse sinkhorn

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,8 @@ License: MIT
 Imports:
     Rcpp,
     RcppArmadillo,
+    irlba,
+    nnls,
     Matrix,
     ggplot2,
     ggrastr,

--- a/R/DualSimplexSolver.R
+++ b/R/DualSimplexSolver.R
@@ -105,21 +105,19 @@ DualSimplexSolver <- R6Class(
       solution_orig = NULL,   # Auto calculated
       marker_genes = NULL     # Auto calculated
     ),
-    set_data = function(data, gene_anno_lists = NULL, sample_anno_lists = NULL) {
+    set_data = function(data, gene_anno_lists = NULL, sample_anno_lists = NULL, sinkhorn_iterations=20) {
       if (any(sapply(dimnames(data), is.null)))
         stop("Genes and samples should be named")
       if (any(sapply(dimnames(data), anyDuplicated)))
         stop("Gene and sample names should not contain duplicates")
 
       first_set = is.null(self$st$data)
-
       private$reset_since("data")
       if (!inherits(data, "ExpressionSet"))
         data <- create_eset(data)
       self$st$data <- add_default_anno(data, gene_anno_lists, sample_anno_lists)
-      self$st$scaling <- sinkhorn_scale(exprs(self$st$data))
+      self$st$scaling <- sinkhorn_scale(exprs(self$st$data), iterations = sinkhorn_iterations)
       self$st$proj_full <- svd_project(self$st$scaling, dims = NULL)
-
       if (first_set) private$add_filtering_log_step("initial")
     },
     plot_mad = function(data, ...) {

--- a/R/sinkhorn.R
+++ b/R/sinkhorn.R
@@ -24,6 +24,8 @@ reverse_sinkhorn <- function(H_row, W_col, scaling) {
   
   dimnames(unscaled$H) <- dimnames(H_row)
   dimnames(unscaled$W) <- dimnames(W_col)
+  dimnames(unscaled$H_row) <- dimnames(H_row)
+  dimnames(unscaled$Dv_inv_W_row) <- dimnames(W_col)
   
   return(unscaled)
 }

--- a/src/sinkhorn.cpp
+++ b/src/sinkhorn.cpp
@@ -39,10 +39,16 @@ Rcpp::List reverse_sinkhorn_c(const arma::mat& result_H_row,
             W_row = W_col * diagmat(D_w_inv_pred_vec);
             H_row = diagmat(1 / D_w_inv_pred_vec) * H_col * arma::diagmat(1 / D_vs_col.col(i - 1));
         }
+        else {
+            // fair estimate of factorization of V using W_row and H_row. For NMF we don't want H to be colnorm
+            W_row = arma::diagmat(1 / D_vs_row.col(0)) * W_row; // this is not row norm anymore.
+        }
     }
 
     return Rcpp::List::create(Rcpp::Named("W") = W_col,
                               Rcpp::Named("H") = H_col,
+                              Rcpp::Named("Dv_inv_W_row") = W_row,
+                              Rcpp::Named("H_row") = H_row,
                               Rcpp::Named("D_ws_col") = D_ws_col,
                               Rcpp::Named("D_hs_row") = D_hs_row);
 }


### PR DESCRIPTION
Hello, I realized that NNLS for for the last iteration of Sinkhorn gives us not that good results. Because this is constraint for H which might not be true. To overcome this issue I suggest return H_row, and D_V*W_row from reverse sinkhorn as well, since these matrices are more precise.

I am not sure if this is a good solution in terms of speed. 