### PR TITLE
Sinkhorn fix

### DIFF
--- a/src/sinkhorn.cpp
+++ b/src/sinkhorn.cpp
@@ -91,42 +91,42 @@ Rcpp::List efficient_sinkhorn(const arma::mat& V,
     arma::mat D_col(max_iter, N);
 
     arma::mat V_ = V;
-
+    D_col_sum_current = 1 / arma::sum(V_, 0);
     // for convergence check
     arma::rowvec converged_col_sum(N, arma::fill::value(1/delta));
     bool converged = false;
 
     // Main algorithm
     int i;
-    for (i = 1; i < max_iter; i++) {
+    for (i = 0; i < max_iter; i++) {
         // Row normalize
         D_row_sum_current = 1 / arma::sum(V_, 1);
-        D_row.col(i-1) = D_row_sum_current;
+        D_row.col(i) = D_row_sum_current;
         V_.each_col() %= D_row_sum_current;
 
         // Column normalize
         D_col_sum_current = 1 / arma::sum(V_, 0);
-        D_col.row(i-1) = D_col_sum_current;
+        D_col.row(i) = D_col_sum_current;
         V_.each_row() %= D_col_sum_current;
 
         // Check convergence
-        if (i >= iter_start_check && ((i-iter_start_check) % check_every_iter) == 0) {
+        if ((i+1) >= iter_start_check && ((i + 1 -iter_start_check) % check_every_iter) == 0) {
             converged = arma::approx_equal(D_col_sum_current, converged_col_sum, "absdiff", epsilon);
         }
         if (converged) break;
     }
 
     if (converged) {
-        Rcpp::Rcout << "Sinkhorn transformation converge at iteration: " << i << ".\n";
+        Rcpp::Rcout << "Sinkhorn transformation converge at iteration: " << (i + 1) << ".\n";
     } else {
-        Rcpp::warning("Sinkhorn transformation does not converge at iteration %i", i);
+        Rcpp::warning("Sinkhorn transformation does not converge at iteration %i", (i+1));
     }
     arma::mat V_column = V_;
     V_.each_row() /= D_col_sum_current;
 
     return Rcpp::List::create(Rcpp::Named("V_row") = V_,
                                 Rcpp::Named("V_column") = V_column,
-                                Rcpp::Named("D_vs_row") = D_row.cols(0, i-1),
-                                Rcpp::Named("D_vs_col") = D_col.rows(0, i-1).t(),
-                                Rcpp::Named("iterations") = i);
+                                Rcpp::Named("D_vs_row") = D_row.cols(0, i),
+                                Rcpp::Named("D_vs_col") = D_col.rows(0, i).t(),
+                                Rcpp::Named("iterations") = (i+1) );
 }

--- a/src/sinkhorn.cpp
+++ b/src/sinkhorn.cpp
@@ -117,12 +117,16 @@ Rcpp::List efficient_sinkhorn(const arma::mat& V,
     }
 
     if (converged) {
-        Rcpp::Rcout << "Sinkhorn transformation converge at iteration: " << (i + 1) << ".\n";
+        Rcpp::Rcout << "Sinkhorn transformation converge at iteration: " << i << ".\n";
     } else {
-        Rcpp::warning("Sinkhorn transformation does not converge at iteration %i", (i+1));
+        Rcpp::warning("Sinkhorn transformation does not converge at iteration %i", i);
     }
     arma::mat V_column = V_;
-    V_.each_row() %= D_col_sum_current;
+    if (i > 0) {
+        // if some normalizations were done. return back halfway to get row normalized matrix
+        V_.each_row() /= D_col_sum_current;
+    }
+
 
     // will return all zero
     return Rcpp::List::create(Rcpp::Named("V_row") = V_,

--- a/src/sinkhorn.cpp
+++ b/src/sinkhorn.cpp
@@ -85,10 +85,10 @@ Rcpp::List efficient_sinkhorn(const arma::mat& V,
     double delta = M / N;
 
     arma::vec D_row_sum_current(M);
-    arma::mat D_row(M, max_iter + 1);
+    arma::mat D_row(M, max_iter + 1, arma::fill::zeros);
 
     arma::rowvec D_col_sum_current(N);
-    arma::mat D_col(max_iter + 1, N);
+    arma::mat D_col(max_iter + 1, N, arma::fill::zeros);
 
     arma::mat V_ = V;
     D_col_sum_current = 1 / arma::sum(V_, 0);
@@ -127,7 +127,7 @@ Rcpp::List efficient_sinkhorn(const arma::mat& V,
     // will return all zero
     return Rcpp::List::create(Rcpp::Named("V_row") = V_,
                                 Rcpp::Named("V_column") = V_column,
-                                Rcpp::Named("D_vs_row") = (i>0) ? D_row.cols(0, i-1) : arma::mat (M, 1, arma::fill::zeros),
-                                Rcpp::Named("D_vs_col") = (i>0) ? D_col.rows(0, i-1).t() : arma::mat (N, 1, arma::fill::zeros),
+                                Rcpp::Named("D_vs_row") = (i>0) ? D_row.cols(0, i-1) :  D_row.cols(0,0),
+                                Rcpp::Named("D_vs_col") = (i>0) ? D_col.rows(0, i-1).t() : D_col.rows(0,0).t(),
                                 Rcpp::Named("iterations") = (i+1) );
 }

--- a/src/sinkhorn.cpp
+++ b/src/sinkhorn.cpp
@@ -85,10 +85,10 @@ Rcpp::List efficient_sinkhorn(const arma::mat& V,
     double delta = M / N;
 
     arma::vec D_row_sum_current(M);
-    arma::mat D_row(M, max_iter);
+    arma::mat D_row(M, max_iter + 1);
 
     arma::rowvec D_col_sum_current(N);
-    arma::mat D_col(max_iter, N);
+    arma::mat D_col(max_iter + 1, N);
 
     arma::mat V_ = V;
     D_col_sum_current = 1 / arma::sum(V_, 0);
@@ -124,9 +124,10 @@ Rcpp::List efficient_sinkhorn(const arma::mat& V,
     arma::mat V_column = V_;
     V_.each_row() /= D_col_sum_current;
 
+    // will return all zero
     return Rcpp::List::create(Rcpp::Named("V_row") = V_,
                                 Rcpp::Named("V_column") = V_column,
-                                Rcpp::Named("D_vs_row") = D_row.cols(0, i),
-                                Rcpp::Named("D_vs_col") = D_col.rows(0, i).t(),
+                                Rcpp::Named("D_vs_row") = (i>0) ? D_row.cols(0, i-1) : arma::mat (M, 1, arma::fill::zeros),
+                                Rcpp::Named("D_vs_col") = (i>0) ? D_col.rows(0, i-1).t() : arma::mat (N, 1, arma::fill::zeros),
                                 Rcpp::Named("iterations") = (i+1) );
 }

--- a/src/sinkhorn.cpp
+++ b/src/sinkhorn.cpp
@@ -122,7 +122,7 @@ Rcpp::List efficient_sinkhorn(const arma::mat& V,
         Rcpp::warning("Sinkhorn transformation does not converge at iteration %i", (i+1));
     }
     arma::mat V_column = V_;
-    V_.each_row() /= D_col_sum_current;
+    V_.each_row() %= D_col_sum_current;
 
     // will return all zero
     return Rcpp::List::create(Rcpp::Named("V_row") = V_,


### PR DESCRIPTION
This fix allows new sinkhorn to do 0 and 1 iterations. 
Changes:
-  create 1 extra column for Dw and Dh to return this column in case of 0 iterations
- prevent 0 division for V_row in case of 0 iterations
- changed back to 0 based numbering
- fixed N-1 iteration actually performed

Tested this with MNIST dataset

```
dso$set_data(data_raw, sinkhorn_iterations=0)
dso$set_data(data_raw, sinkhorn_iterations=1)
```